### PR TITLE
URGENT: Add simple test routes without middleware

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,6 +20,24 @@ const { createStandardBodyParser, createPayloadErrorHandler } = require('./middl
 const app  = express();
 const port = process.env.PORT || 3000;
 
+// SIMPLE TEST - aucun middleware, juste du JSON brut
+app.get('/test-simple', (req, res) => {
+  res.json({ message: 'Simple test works', timestamp: Date.now() });
+});
+
+app.get('/test-debug', (req, res) => {
+  const info = {
+    nodeVersion: process.version,
+    platform: process.platform,
+    env: process.env.NODE_ENV,
+    port: port,
+    mongoConnected: mongoose.connection.readyState === 1,
+    timestamp: new Date().toISOString()
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(info, null, 2));
+});
+
 // 1) Enhanced Security headers with nonce-based CSP
 app.use(createSecurityMiddleware());
 


### PR DESCRIPTION
Adding /test-simple and /test-debug routes BEFORE any middleware to isolate if the issue is with middleware or core Express functionality.

This will help identify if:
1. Basic JSON responses work
2. The issue is with specific middleware
3. MongoDB connection affects all endpoints

🤖 Generated with Claude Code