### PR TITLE
Fix HTML entity display issues for special characters

### DIFF
--- a/frontend/admin/admin-utils.js
+++ b/frontend/admin/admin-utils.js
@@ -164,14 +164,41 @@ function escapeHTML(text) {
 }
 
 /**
- * Décode les entités HTML (inverse d'escapeHTML)
+ * Décode uniquement les entités HTML sûres (liste blanche)
  * @param {string} text - Texte contenant des entités HTML
  * @returns {string} - Texte avec entités décodées
  */
 function unescapeHTML(text) {
-  const div = document.createElement('div');
-  div.innerHTML = text;
-  return div.textContent || div.innerText || '';
+  if (!text || typeof text !== 'string') return text || '';
+  
+  // Approche liste blanche : décoder uniquement les entités communes et sûres
+  const safeEntityMap = {
+    '&#x27;': "'",
+    '&#39;': "'",
+    '&apos;': "'",
+    '&quot;': '"',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&nbsp;': ' ',
+    '&eacute;': 'é',
+    '&egrave;': 'è',
+    '&ecirc;': 'ê',
+    '&agrave;': 'à',
+    '&acirc;': 'â',
+    '&ugrave;': 'ù',
+    '&ucirc;': 'û',
+    '&icirc;': 'î',
+    '&ocirc;': 'ô',
+    '&ccedil;': 'ç'
+  };
+  
+  let result = text;
+  for (const [entity, char] of Object.entries(safeEntityMap)) {
+    result = result.replace(new RegExp(entity, 'g'), char);
+  }
+  
+  return result;
 }
 
 /**

--- a/frontend/admin/admin-utils.js
+++ b/frontend/admin/admin-utils.js
@@ -164,6 +164,17 @@ function escapeHTML(text) {
 }
 
 /**
+ * Décode les entités HTML (inverse d'escapeHTML)
+ * @param {string} text - Texte contenant des entités HTML
+ * @returns {string} - Texte avec entités décodées
+ */
+function unescapeHTML(text) {
+  const div = document.createElement('div');
+  div.innerHTML = text;
+  return div.textContent || div.innerText || '';
+}
+
+/**
  * Formate une date au format français
  * @param {string|Date} date - Date à formater
  * @returns {string} - Date formatée
@@ -303,7 +314,8 @@ function createAnswersList(items, config = {}) {
       li.appendChild(img);
       li.appendChild(document.createTextNode(` ${user}`));
     } else {
-      li.textContent = `${user} : ${answer}`;
+      // Décoder les entités HTML pour un affichage correct
+      li.textContent = `${user} : ${unescapeHTML(answer)}`;
     }
 
     ul.appendChild(li);
@@ -377,6 +389,7 @@ if (typeof module !== 'undefined' && module.exports) {
     fetchWithErrorHandling,
     fetchCSRFToken,
     escapeHTML,
+    unescapeHTML,
     formatDateFR,
     debounce,
     createPieChart,

--- a/frontend/admin/admin.html
+++ b/frontend/admin/admin.html
@@ -175,10 +175,10 @@
       const card = document.createElement('div');
       card.className = "bg-white shadow rounded p-4 mb-4";
 
-      // Titre
+      // Titre (décoder les entités HTML)
       const h2 = document.createElement('h2');
       h2.className = "text-lg font-bold mb-2";
-      h2.textContent = question;
+      h2.textContent = unescapeHTML(question);
       card.appendChild(h2);
 
       if (question === CONFIG.pieQuestion) {

--- a/frontend/public/view.html
+++ b/frontend/public/view.html
@@ -10,12 +10,38 @@
   <div id="qa-container"></div>
 
   <script>
-    // Fonction pour décoder les entités HTML
+    // Fonction pour décoder uniquement les entités HTML sûres (liste blanche)
     function unescapeHTML(text) {
-      if (!text) return text;
-      const div = document.createElement('div');
-      div.innerHTML = text;
-      return div.textContent || div.innerText || '';
+      if (!text || typeof text !== 'string') return text || '';
+      
+      // Approche liste blanche : décoder uniquement les entités communes et sûres
+      const safeEntityMap = {
+        '&#x27;': "'",
+        '&#39;': "'",
+        '&apos;': "'",
+        '&quot;': '"',
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&nbsp;': ' ',
+        '&eacute;': 'é',
+        '&egrave;': 'è',
+        '&ecirc;': 'ê',
+        '&agrave;': 'à',
+        '&acirc;': 'â',
+        '&ugrave;': 'ù',
+        '&ucirc;': 'û',
+        '&icirc;': 'î',
+        '&ocirc;': 'ô',
+        '&ccedil;': 'ç'
+      };
+      
+      let result = text;
+      for (const [entity, char] of Object.entries(safeEntityMap)) {
+        result = result.replace(new RegExp(entity, 'g'), char);
+      }
+      
+      return result;
     }
 
     (async () => {
@@ -31,18 +57,33 @@
       user.responses.forEach((q, i) => {
         const block = document.createElement('div');
         
-        // Décoder les entités HTML pour un affichage correct
+        // Décoder les entités HTML de manière sécurisée
         const question = unescapeHTML(q.question);
         const answer = unescapeHTML(q.answer);
-        const adminAnswer = admin && admin.responses[i] 
-          ? unescapeHTML(admin.responses[i].answer)
-          : '<em>Pas encore répondu</em>';
 
-        block.innerHTML = `
-          <h2>Q${i+1} : ${question}</h2>
-          <p><strong>Vous :</strong> ${answer}</p>
-          <p class="admin-answer"><strong>Moi (Admin) :</strong> ${adminAnswer}</p>
-        `;
+        // Créer les éléments de manière sécurisée (pas d'innerHTML)
+        const questionElement = document.createElement('h2');
+        questionElement.textContent = `Q${i+1} : ${question}`;
+
+        const yourAnswer = document.createElement('p');
+        yourAnswer.innerHTML = `<strong>Vous :</strong> `;
+        yourAnswer.appendChild(document.createTextNode(answer));
+
+        const adminAnswerElement = document.createElement('p');
+        adminAnswerElement.className = 'admin-answer';
+        adminAnswerElement.innerHTML = `<strong>Moi (Admin) :</strong> `;
+        if (admin && admin.responses[i]) {
+          const adminAnswerText = unescapeHTML(admin.responses[i].answer);
+          adminAnswerElement.appendChild(document.createTextNode(adminAnswerText));
+        } else {
+          const emElement = document.createElement('em');
+          emElement.textContent = 'Pas encore répondu';
+          adminAnswerElement.appendChild(emElement);
+        }
+
+        block.appendChild(questionElement);
+        block.appendChild(yourAnswer);
+        block.appendChild(adminAnswerElement);
         document.getElementById('qa-container').append(block);
       });
     })();

--- a/frontend/public/view.html
+++ b/frontend/public/view.html
@@ -10,6 +10,14 @@
   <div id="qa-container"></div>
 
   <script>
+    // Fonction pour décoder les entités HTML
+    function unescapeHTML(text) {
+      if (!text) return text;
+      const div = document.createElement('div');
+      div.innerHTML = text;
+      return div.textContent || div.innerText || '';
+    }
+
     (async () => {
       const token = location.pathname.split('/').pop();
       const res = await fetch(`/api/view/${token}`);
@@ -22,10 +30,18 @@
 
       user.responses.forEach((q, i) => {
         const block = document.createElement('div');
+        
+        // Décoder les entités HTML pour un affichage correct
+        const question = unescapeHTML(q.question);
+        const answer = unescapeHTML(q.answer);
+        const adminAnswer = admin && admin.responses[i] 
+          ? unescapeHTML(admin.responses[i].answer)
+          : '<em>Pas encore répondu</em>';
+
         block.innerHTML = `
-          <h2>Q${i+1} : ${q.question}</h2>
-          <p><strong>Vous :</strong> ${q.answer}</p>
-          <p class="admin-answer"><strong>Moi (Admin) :</strong> ${admin && admin.responses[i] ? admin.responses[i].answer : '<em>Pas encore répondu</em>'}</p>
+          <h2>Q${i+1} : ${question}</h2>
+          <p><strong>Vous :</strong> ${answer}</p>
+          <p class="admin-answer"><strong>Moi (Admin) :</strong> ${adminAnswer}</p>
         `;
         document.getElementById('qa-container').append(block);
       });


### PR DESCRIPTION
- Add unescapeHTML() function to decode HTML entities (&#x27;, &quot;, etc.)
- Update view.html to properly display apostrophes and quotes
- Fix admin interface to decode HTML entities in questions and answers
- Ensure special characters display correctly instead of as HTML entities

This resolves the issue where apostrophes appeared as &#x27; instead of ' and other HTML entities were shown as raw code rather than the intended characters.

🤖 Generated with [Claude Code](https://claude.ai/code)