### PR TITLE
🔒 SECURITY: Fix CSS loading CSP violations

### DIFF
--- a/frontend/public/auth-choice.html
+++ b/frontend/public/auth-choice.html
@@ -7,8 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Bienvenue sur FAF - Form a Friend</title>
-    <link rel="stylesheet" href="/css/shared-base.css" nonce="{{nonce}}">
-    <link rel="stylesheet" href="/css/auth-choice.css" nonce="{{nonce}}">
+    <link rel="stylesheet" href="/css/shared-base.css">
+    <link rel="stylesheet" href="/css/auth-choice.css">
 </head>
 <body>
     <div class="container">

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Connexion - FAF</title>
-    <link rel="stylesheet" href="/css/shared-base.css" nonce="{{nonce}}">
-    <link rel="stylesheet" href="/css/login.css" nonce="{{nonce}}">
+    <link rel="stylesheet" href="/css/shared-base.css">
+    <link rel="stylesheet" href="/css/login.css">
 </head>
 <body>
     <div class="form-container">

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inscription - FAF</title>
-    <link rel="stylesheet" href="/css/shared-base.css" nonce="{{nonce}}">
-    <link rel="stylesheet" href="/css/register.css" nonce="{{nonce}}">
+    <link rel="stylesheet" href="/css/shared-base.css">
+    <link rel="stylesheet" href="/css/register.css">
 </head>
 <body>
     <div class="container">
@@ -136,7 +136,7 @@
                     successMessage.style.display = 'block';
                     
                     setTimeout(() => {
-                        window.location.href = '/login.html?registered=1';
+                        window.location.href = '/login?registered=1';
                     }, 2000);
                 } else {
                     displayErrors(result.errors || [{ msg: result.error || 'Erreur lors de la création du compte' }]);


### PR DESCRIPTION
- Remove nonce attributes from <link rel='stylesheet'> tags
- Fix redirect from /login.html to /login after registration
- External CSS files use 'self' directive, not nonces
- Keep nonces only on inline <script> and <style> tags
- Resolves 'Refused to apply stylesheet' CSP errors